### PR TITLE
Add automatic release process for extension

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+name: Deploy Extension
+on:
+  push:
+    tags:
+      - "*"
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - name: Publish to Open VSX Registry
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+          registryUrl: https://open-vsx.org
+      - name: Publish to Visual Studio Marketplace
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+          registryUrl: https://marketplace.visualstudio.com


### PR DESCRIPTION
Fixes #6

Releases the extension on the Microsoft VSCode marketplace and the open vsx marketplace.

Todos:
- [x] Add the secret for the Microsoft marketplace
- [x] Register the organization at https://open-vsx.org in order to obtain an access token
- [x] Add the access token for open-vsx to the Github repo.
- [ ] Document how to cut a release using the new setup
- [ ] Possibly some test which checks that the version in the `package.json` and the git tag agree.