### PR TITLE
Add `note` to the set of syntax-highlighted keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The date format is `YYYY-MM-DD`.
 
+## [Unreleased]
+
+- Add `note` to the set of syntax-highlighted keywords
+
 ## [0.0.11] - 2025-03-31
 
 - Add `infix` to the set of syntax-highlighted keywords

--- a/syntaxes/pol.tmLanguage.json
+++ b/syntaxes/pol.tmLanguage.json
@@ -12,7 +12,7 @@
       "patterns": [
         {
           "name": "keyword.control",
-          "match": "\\b(data|codata|let|def|codef|match|comatch|absurd|Type|implicit|use|infix)\\b"
+          "match": "\\b(data|codata|let|def|codef|match|comatch|absurd|Type|implicit|use|infix|note)\\b"
         }
       ]
     },


### PR DESCRIPTION
In <https://github.com/polarity-lang/polarity/pull/572>, we introduce a new `note` keyword. This adds the keyword to our VSCode grammar.